### PR TITLE
Add more flexible BWA table arguments

### DIFF
--- a/bioseqdb_pg/bioseqdb--0.0.0.sql
+++ b/bioseqdb_pg/bioseqdb--0.0.0.sql
@@ -55,12 +55,12 @@ CREATE TYPE bwa_result AS (
     score INTEGER
 );
 
-CREATE FUNCTION nuclseq_search_bwa(NUCLSEQ, CSTRING, CSTRING, CSTRING)
+CREATE FUNCTION nuclseq_search_bwa(query_sequence NUCLSEQ, reference_sql CSTRING)
     RETURNS SETOF bwa_result
     AS 'MODULE_PATHNAME'
     LANGUAGE C STABLE STRICT;
 
-CREATE FUNCTION nuclseq_multi_search_bwa(CSTRING,  CSTRING, CSTRING, CSTRING, CSTRING, CSTRING)
+CREATE FUNCTION nuclseq_multi_search_bwa(query_sql CSTRING, reference_sql CSTRING)
     RETURNS SETOF bwa_result
     AS 'MODULE_PATHNAME'
     LANGUAGE C STABLE STRICT;


### PR DESCRIPTION
Building the SQL query from a table name and column names doesn't let us run useful queries like `WITH small_sequence_set AS (SELECT * FROM dataset LIMIT 100) SELECT * FROM nuclseq_search_bwa('TGTGAGCTTTATCACTACCAAG', 'small_sequence_set', 'id', 'seq');`, because `small_sequence_set` is apparently not accessible to SPI the same way normal tables do. Accepting a full SQL query instead makes it possible to write queries such as `SELECT * FROM nuclseq_search_bwa('TGTGAGCTTTATCACTACCAAG', 'SELECT id, seq FROM dataset LIMIT 100');`.